### PR TITLE
Fix plot layout for large datasets

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -34,7 +34,7 @@ button:disabled {
 }
 
 .plot-wrapper {
-  overflow-x: hidden;
+  overflow-x: auto;
   margin: 0 auto;
   width: 100%;
 }

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -51,7 +51,7 @@ function SignalPlot({ data, windowIndex }) {
   return (
     <div className="plot-wrapper">
       <svg
-        width="100%"
+        width={svgWidth}
         height={svgHeight}
         viewBox={`0 0 ${svgWidth} ${svgHeight}`}
         className="plot"


### PR DESCRIPTION
## Summary
- allow horizontal scrolling for plot wrappers
- size SVGs using calculated width so the graph doesn't overflow the page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*